### PR TITLE
Use systems from blueprint, if not specified

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -101,7 +101,7 @@ let
         config = { };
       },
       # The systems to generate the flake for
-      systems ? inputs.systems,
+      systems ? inputs.systems or bpInputs.systems,
     }:
     (
       { inputs }:


### PR DESCRIPTION
...in inputs of the users flake.

Without this, the examples in README.md and templates don't work for me as the miss this input. (nix 2.18.2)